### PR TITLE
Remove hardcoded user base-directory

### DIFF
--- a/config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
+++ b/config/xfce4/xfconf/xfce-perchannel-xml/xfce4-panel.xml
@@ -71,8 +71,5 @@
       </property>
     </property>
     <property name="plugin-13" type="string" value="separator"/>
-    <property name="plugin-14" type="string" value="directorymenu">
-      <property name="base-directory" type="string" value="/home/user"/>
-    </property>
   </property>
 </channel>


### PR DESCRIPTION
As default username is now configurable at installation time, remove the hardcoded reference to /home/user/ direcotry in xfce4-panel